### PR TITLE
fix(bibliothèque): rendre le nombre d'ouvrages dynamique

### DIFF
--- a/content/en/activites/bibliotheque.md
+++ b/content/en/activites/bibliotheque.md
@@ -4,10 +4,3 @@ description: "SAR France library inventory"
 layout: "bibliotheque"
 outputs: [html, json]
 ---
-
-## SAR France Library
-
-SAR France holds a library of over 350 works covering the history of the American War of Independence, biographies of key figures of the era, maritime history, genealogy, and many other subjects related to the Franco-American alliance.
-
-All books are available for consultation upon request to the SAR France [secretariat](/en/contact/#secretariat).
-

--- a/content/fr/activites/bibliotheque.md
+++ b/content/fr/activites/bibliotheque.md
@@ -4,10 +4,3 @@ description: "Inventaire de la bibliothèque SAR France"
 layout: "bibliotheque"
 outputs: [html, json]
 ---
-
-## Bibliothèque SAR France
-
-SAR France dispose d'une bibliothèque riche de plus de 350 ouvrages couvrant l'histoire de la Guerre d'Indépendance américaine, les biographies des acteurs de cette époque, l'histoire maritime, la généalogie et bien d'autres sujets liés à l'alliance franco-américaine.
-
-Tous les ouvrages sont consultables sur demande auprès du [secrétariat](/contact/#secretariat) de SAR France.
-

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -128,6 +128,8 @@
   translation: "Last updated"
 
 # Library
+- id: bibli_intro
+  translation: "SAR France holds a library of {{ .Count }} works covering the history of the American War of Independence, biographies of key figures of the era, maritime history, genealogy, and many other subjects related to the Franco-American alliance."
 - id: bibli_desc
   translation: "SAR France library inventory"
 - id: bibli_count

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -128,6 +128,8 @@
   translation: "Dernière mise à jour"
 
 # Bibliothèque
+- id: bibli_intro
+  translation: "SAR France dispose d'une bibliothèque riche de {{ .Count }} ouvrages couvrant l'histoire de la Guerre d'Indépendance américaine, les biographies des acteurs de cette époque, l'histoire maritime, la généalogie et bien d'autres sujets liés à l'alliance franco-américaine."
 - id: bibli_desc
   translation: "Inventaire de la bibliothèque SAR France"
 - id: bibli_count

--- a/themes/sarfrance/layouts/activites/bibliotheque.html
+++ b/themes/sarfrance/layouts/activites/bibliotheque.html
@@ -8,7 +8,8 @@
     {{ partial "page-header.html" (dict "ctx" . "desc" (i18n "bibli_desc") "extra" $bibMeta) }}
     <div class="container">
         <div class="content">
-            {{ .Content }}
+            <p>{{ i18n "bibli_intro" (dict "Count" (len .Site.Data.books.books)) }}</p>
+            <p>{{ i18n "bibli_available" | safeHTML }}</p>
         </div>
 
         <div class="page-search-wrap">


### PR DESCRIPTION
## Problème

Le texte d'introduction de la page Bibliothèque affichait **« plus de 350 ouvrages »** en dur dans le Markdown, alors que l'en-tête de page comptait dynamiquement **453 livres** depuis `data/books.yaml` (cf. #5).

## Solution

Le nombre d'ouvrages est désormais calculé automatiquement à partir de `data/books.yaml` via une clé i18n avec placeholder :

- Nouvelle clé `bibli_intro` dans `i18n/fr.yaml` et `i18n/en.yaml` avec `{{ .Count }}`
- Le template injecte `len .Site.Data.books.books` dans le placeholder
- Le texte de consultation utilise la clé `bibli_available` existante
- Le contenu Markdown redondant a été supprimé (front matter conservé)

## Fichiers modifiés

| Fichier | Modification |
|---------|-------------|
| `i18n/fr.yaml` | Ajout clé `bibli_intro` avec `{{ .Count }}` |
| `i18n/en.yaml` | Ajout clé `bibli_intro` avec `{{ .Count }}` |
| `themes/sarfrance/layouts/activites/bibliotheque.html` | Remplacement de `.Content` par les clés i18n dynamiques |
| `content/fr/activites/bibliotheque.md` | Suppression du texte en dur |
| `content/en/activites/bibliotheque.md` | Suppression du texte en dur |

## Résultat

Le compteur s'adaptera automatiquement à chaque ajout ou suppression de livre dans `data/books.yaml`, sans intervention manuelle.

Closes #5